### PR TITLE
Bugfix/select many

### DIFF
--- a/mc/Voyage-Model-Core.package/VOExternalRepository.class/instance/selectMany.where.sortBy..st
+++ b/mc/Voyage-Model-Core.package/VOExternalRepository.class/instance/selectMany.where.sortBy..st
@@ -1,7 +1,7 @@
 persistence
 selectMany: aClass where: aBlock sortBy: sortBlock
 	^ self selectManyOperation
-		queryClass: self;
+		queryClass: aClass;
 		where: aBlock;
 		sortBlock: sortBlock;
 		execute

--- a/mc/Voyage-Model-Tests.package/VORepositoryTest.class/instance/testSelectManyWithSortBlock.st
+++ b/mc/Voyage-Model-Tests.package/VORepositoryTest.class/instance/testSelectManyWithSortBlock.st
@@ -13,5 +13,5 @@ testSelectManyWithSortBlock
 	self waitForWriteOperation.
 	fetched := self repository
 		selectMany: VOTestPilot
-		where: nil
+		where: [ :each | each name notNil ]
 		sortBy: #name

--- a/mc/Voyage-Model-Tests.package/VORepositoryTest.class/instance/testSelectManyWithSortBlock.st
+++ b/mc/Voyage-Model-Tests.package/VORepositoryTest.class/instance/testSelectManyWithSortBlock.st
@@ -1,0 +1,17 @@
+tests
+testSelectManyWithSortBlock
+	| fetched |
+	self repository
+		save: (VOTestPilot new name: 'Esteban');
+		save: (VOTestPilot new name: 'Mariano');
+		save: (VOTestPilot new name: 'Stef');
+		save: (VOTestPilot new name: 'Camillo');
+		save: (VOTestPilot new name: 'Igor');
+		save: (VOTestPilot new name: 'Markus');
+		yourself.
+	self repository flushCache.
+	self waitForWriteOperation.
+	fetched := self repository
+		selectMany: VOTestPilot
+		where: nil
+		sortBy: #name


### PR DESCRIPTION
VOExternalRepository has a bug in the `selectMany:where:sortBy:` method which makes it not query the mongo collection object. 